### PR TITLE
Initial version of lcms ETL

### DIFF
--- a/reactors/lcms/Dockerfile
+++ b/reactors/lcms/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7.13
+
+ADD src/lcms.py /
+
+RUN pip install argparse
+RUN pip install pandas
+RUN pip install pyteomics
+RUN pip install lxml
+
+CMD python ./lcms.py --in $IN --out $OUT

--- a/reactors/lcms/build.sh
+++ b/reactors/lcms/build.sh
@@ -1,0 +1,1 @@
+docker build -t lcms .

--- a/reactors/lcms/run.sh
+++ b/reactors/lcms/run.sh
@@ -1,0 +1,1 @@
+docker run -v $PWD:/data -e "IN=/data/ec_K12.fasta" -e "OUT=/data/out.txt" lcms

--- a/reactors/lcms/src/lcms.py
+++ b/reactors/lcms/src/lcms.py
@@ -1,0 +1,58 @@
+"""Tool to parse mass spec files using R's xcms file
+
+This is a tool to auto-generate data set summaries.
+
+Example:
+    Recommended way to run this tool is:
+
+        $ python lcms.py --in <input_filename> --out <output_filename>
+
+"""
+import pandas as pd
+import numpy as np
+import argparse
+from pyteomics import mgf, mzml, fasta, auxiliary 
+
+def ingest_mgf(input_filename):
+    """Ingest an mgf file given it's name and return a dataframe of the file
+    """
+    with mgf.read('tests/test.mgf') as reader:
+        auxiliary.print_tree(next(reader))
+
+def ingest_fasta(input_filename):
+    """Ingest an fasta file given it's name and return a dataframe of the file
+    """
+    with fasta.read(input_filename) as reader:
+        for entry in reader:
+            prot_list = [[item.description.split("|")[0]+":"+item.description.split("|")[1],
+                          item.description.split("|")[3],item.description.split("|")[4],item.sequence] for item in reader]
+    df = pd.DataFrame(prot_list,columns=["GeneInfo ID","Accession","Description","Sequence"])
+    return df
+        
+def ingest_mzML(input_filename):
+    """Ingest an mzML or mzXML file given it's name and return a dataframe of the file
+    """
+    with mzml.read('tests/test.mzML') as reader:
+        auxiliary.print_tree(next(reader))
+        
+def main():
+    
+    #Parse the arguments to read in the file name and export another file
+    parser = argparse.ArgumentParser(description='LC/MS ETL')
+    parser.add_argument("--in", help="Input Filename",  required=True)
+    parser.add_argument("--out", help="Output Filename", required=True)
+    args = vars(parser.parse_args())
+    
+    #variables will be
+    print "args",args["in"],"---",args["out"]
+    
+    if "mgf" in args["in"]:
+        ingest_mgf(args["in"])
+    elif "fasta" in args["in"]:
+        df = ingest_fasta(args["in"])
+        print df.shape
+    else:
+        ingest_mzML(args["in"])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Contains an initial version of an lcms ETL processor

Should be pretty straightforward - build.sh to build and run.sh to test a run. 

Currently parameterized with an external .fasta file for the test run - @mwvaughn I don't want to store this in git (1.8MB) - any suggestions from the TACC perspective on where to put this (S3 bucket? Somewhere else?)

Currently outputs the shape the Dataframe created - intended for downstream consumers

Volume mapping and parameter passing are initial - more work to be done here.

@meslami-netrias contributed to this as well. 