### PR TITLE
ETL parser for MSF mass-spec files

### DIFF
--- a/reactors/msf/Dockerfile
+++ b/reactors/msf/Dockerfile
@@ -1,0 +1,30 @@
+# Pin to a specific major version, not latest
+# xenial = 16.0.4 LTS
+# trusty = 14.0.4 LTS
+
+FROM ubuntu:xenial
+
+RUN apt-get update
+RUN apt-get install python -y
+RUN apt-get install python-pip -y
+RUN pip install --upgrade pip
+RUN pip install pandas
+
+# Customizing 101
+# 
+# 1. Try to avoid working in / (unless that's your intent)
+# 2. Do ADD and COPY operations as late as possible as 
+#    they invalidate the Docker cache on downstream layers
+# 3. Import archive files from GitHub using tagged releases
+# 4. Clean up your build directories when done
+# 5. Put scripts and other assets in relatively standard places
+# 6. Don't actually have the default ENTRYPOINT or 
+#    CMD do work. Enlist it for debugging instead.
+
+WORKDIR /root
+
+RUN mkdir -p /opt/scripts
+
+ADD src /opt/scripts
+
+CMD /usr/bin/env

--- a/reactors/msf/build.sh
+++ b/reactors/msf/build.sh
@@ -1,0 +1,1 @@
+docker build -t msf .

--- a/reactors/msf/example/_util/container_exec.sh
+++ b/reactors/msf/example/_util/container_exec.sh
@@ -1,0 +1,58 @@
+
+function container_exec() {
+    
+    # [TODO] Check for existence of docker or singularity executable
+    # [TODO] Enable honoring a DEBUG global
+    # [TODO] Figure out how to accept more optional arguments (env-file, etc)
+    # [TODO] Better error handling and reporting
+
+    local CONTAINER_IMAGE=$1
+    shift
+    local COMMAND=$1
+    shift
+    local PARAMS=$@
+
+    echo $CONTAINER_IMAGE
+    echo $COMMAND
+    echo $PARAMS
+
+    if [ -z "$SINGULARITY_PULLFOLDER" ];
+    then
+        if [ ! -z "$STOCKYARD" ];
+        then
+            SINGULARITY_PULLFOLDER="${STOCKYARD}/.singularity/pull"
+        else
+            SINGULARITY_PULLFOLDER="$HOME/.singularity"
+        fi
+    fi
+
+    if [ -z "$SINGULARITY_CACHEDIR" ];
+    then
+        if [ ! -z "$STOCKYARD" ];
+        then
+            SINGULARITY_CACHEDIR="${STOCKYARD}/.singularity/cache"
+        else
+            SINGULARITY_CACHEDIR="$HOME/.singularity"
+        fi
+    fi
+
+    if [[ "$_CONTAINER_ENGINE" == "docker" ]];
+    then
+        local OPTS="-v $PWD:/home:rw -w /home --rm=true"
+        if [ ! -z "$ENVFILE" ]
+        then
+            OPTS="$OPTS --env-file ${ENVFILE}"
+        fi
+        set -x
+        docker run $OPTS ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}
+        set +x
+    elif [[ "$_CONTAINER_ENGINE" == "singularity" ]];
+    then
+        # [TODO] Detect if a .img has been passed it (rare)
+        # [TODO]
+        singularity exec docker://${DOCKER_CONTAINER} "${COMMAND}"
+    else
+        echo "_CONTAINER_ENGINE needs to be 'docker' or 'singularity' [$_CONTAINER_ENGINE]"
+    fi
+
+}

--- a/reactors/msf/example/agave-runner.sh
+++ b/reactors/msf/example/agave-runner.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script simulates the job execution environment for TACC's Agave
+# platform. An emphemeral working directory has been created, files have
+# been copied into place at the root level of that directory, and a
+# task runner has been written out to the directory (*.ipcexe). In a 
+# batch (HPC) system, the script will be actually be a scheduler job 
+# script while on an interactive (CLI) system, the script itself is 
+# executed in this directory on the host
+
+_CONTAINER_ENGINE=${_CONTAINER_ENGINE:-docker} 
+. _util/container_exec.sh
+
+CONTAINER_IMAGE="msf:latest"
+COMMAND='python'
+PARAMS='/opt/scripts/msf.py --file exp2801-04-ds731218.msf --output exp2801-04-ds73121.csv'
+
+container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}

--- a/reactors/msf/example/agave-runner.sh.ipcexe
+++ b/reactors/msf/example/agave-runner.sh.ipcexe
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This script simulates the job execution environment for TACC's Agave
+# platform. An emphemeral working directory has been created, files have
+# been copied into place at the root level of that directory, and a
+# task runner has been written out to the directory (*.ipcexe). In a 
+# batch (HPC) system, the script will be actually be a scheduler job 
+# script while on an interactive (CLI) system, the script itself is 
+# executed in this directory on the host
+
+_CONTAINER_ENGINE=${_CONTAINER_ENGINE:-singularity}
+. _util/container_exec.sh
+
+CONTAINER_IMAGE="sd2e/msf:latest" # ${docker_org}${docker_image}${image_tag}
+# ${file1} ${label1} ${type} ${output}
+COMMAND='python'
+PARAMS='/opt/scripts/msf.py --file exp2801-04-ds731218.msf --output exp2801-04-ds73121.csv'
+
+container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}

--- a/reactors/msf/example/app.json
+++ b/reactors/msf/example/app.json
@@ -1,0 +1,62 @@
+{
+    "checkpointable": false,
+    "name": "msf",
+    "executionSystem": "hpc-tacc-maverick",
+    "executionType": "HPC",
+    "deploymentPath": "apps/msf",
+    "deploymentSystem": "data-sd2e-app-assets",
+    "helpURI": "https://sd2e.org/develop/",
+    "label": "MSF Parser",
+    "longDescription": "",
+    "modules": ["load tacc-singularity/2.3.1"],
+    "ontology": ["http://sswapmeet.sswap.info/agave/apps/Application"],
+    "parallelism": "SERIAL",
+    "shortDescription": "",
+    "tags": ["msf"],
+    "templatePath": "agave-runner.sh",
+    "testPath": "agave-tester.sh",
+    "version": "0.1.0",
+    "inputs": [{
+      "id": "files",
+      "details": {
+        "label": "MSF file",
+        "showAttribute": false
+      },
+      "semantics": {
+        "minCardinality": 1,
+        "ontology": [
+          "http://sswapmeet.sswap.info/util/Sequence"
+        ],
+        "fileTypes": [
+          "text-0"
+        ]
+      },
+      "value": {
+        "default": "agave://data-tacc-work-vaughn/examples/wc/test.txt",
+        "required": true,
+        "visible": true
+      }
+    }],
+    "parameters": [
+        {
+            "id": "output",
+            "value": {
+                "default": "output",
+                "type": "string",
+                "validator": "",
+                "visible": true,
+                "required": false
+            },
+            "details": {
+                "label": "Output file name"
+            },
+            "semantics": {
+                "ontology": [
+                    "xs:string"
+                ]
+            }
+        }
+    ],
+    "outputs": [],
+    "defaultMaxRunTime": "00:15:00"
+}

--- a/reactors/msf/example/app.jsonx
+++ b/reactors/msf/example/app.jsonx
@@ -1,0 +1,23 @@
+{
+	"checkpointable": false,
+	"name": "${APP_NAME}",
+	"executionSystem": "${APP_EXECUTIONSYSTEM}",
+	"executionType": "${APP_TYPE}",
+	"deploymentPath": "apps/docker-run",
+	"deploymentSystem": "data-sd2e-app-assets",
+	"helpURI": "https://sd2e.org/develop/",
+	"label": "docker run (${APP_TYPE})",
+	"longDescription": "Automatically generated: ${GENDATE}",
+	"modules": ['load singularity'],
+	"ontology": ["http://sswapmeet.sswap.info/agave/apps/Application"],
+	"parallelism": "SERIAL",
+	"shortDescription": "Pull and execute the default ENTRYPOINT of a Docker container image using Singularity",
+	"tags": ["test", "hello"],
+	"templatePath": "code/runner.sh",
+	"testPath": "code/tester.sh",
+	"version": "${APP_VERSION}",
+	"inputs": [],
+	"parameters": [],
+	"outputs": [],
+	"defaultMaxRunTime": "00:10:00"
+}

--- a/reactors/msf/example/app.yml
+++ b/reactors/msf/example/app.yml
@@ -1,0 +1,18 @@
+---
+inputs:
+  files:
+    default_value: "file:///exp2801-04-ds731218.msf"
+    test_value: "file:///exp2801-04-ds731218.msf"
+    label: "MSF file"
+  config:
+    default_value: "file:///msf.json"
+    test_value: "file:///msf.json"
+    label: "Configuration file (JSON)"
+parameters:
+outputs:
+runtime:
+  template: "agave-runner.sh"
+  container:
+    docker_org: "sd2e/"
+    docker_image: "msf"
+    image_tag: ":latest"

--- a/reactors/msf/src/msf.py
+++ b/reactors/msf/src/msf.py
@@ -1,0 +1,134 @@
+import argparse
+import sqlite3
+import pandas as pd
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--files', help='Input MSF file(s) for parsing', required=True)
+parser.add_argument('--output', help='Name of output CS  file', default='output.csv')
+
+class ProteomeDiscovererMSF():
+
+    def __init__(self, path_to_MSF):
+        self.path = path_to_MSF
+        self.con = sqlite3.connect(path_to_MSF)
+        self.cur = self.con.cursor()
+    
+    def proteins(self, name_contains=None, sequence_contains=None, protein_id=None):
+        query = """
+                SELECT P.ProteinID, 
+                       P.Sequence, 
+                       PA.Description, 
+                       PS.ProteinScore, 
+                       PS.Coverage 
+                FROM Proteins AS P 
+                JOIN ProteinAnnotations AS PA ON P.ProteinID=PA.ProteinID
+                JOIN ProteinScores as PS ON P.ProteinID=PS.ProteinID
+                """
+        if name_contains:
+            query += 'WHERE PA.Description LIKE "%' + str(name_contains) + '%" '
+        if sequence_contains:
+            query += 'WHERE P.Sequence LIKE "%' + str(sequence_contains) + '%" '
+        if protein_id:
+            query += 'WHERE P.ProteinID=' + str(protein_id)
+              
+        proteins = []
+        try:
+            for item in self.cur.execute(query):
+                proteins.append({
+                             'protein_id': item[0],
+                             'sequence': item[1],
+                             'description': item[2],
+                             'protein_score': item[3],
+                             'coverage': item[4]
+                            })
+        except sqlite3.OperationalError:
+            pass
+
+        output = pd.DataFrame(proteins)
+        return output
+
+
+    def peptides(self, 
+                 sequence=None, 
+                 protein_id=None, 
+                 protein_description=None, 
+                 peptide_min_score=None, 
+                 best=False, 
+                 scan_number=None, 
+                 confidence_level=None, 
+                 search_engine_rank=None):
+        query = """
+                SELECT Pep.Sequence, 
+                """
+          
+        if best:
+            query += "    MAX(PepS.ScoreValue),"
+        else:    
+            query += "    PepS.ScoreValue,"
+              
+        query += """
+                    PA.ProteinID,
+                    PA.Description,
+                    SH.ScanNumbers,
+                    SH.Mass,
+                    SH.Charge,
+                    SH.RetentionTime
+                FROM Peptides AS Pep
+                JOIN PeptidesProteins AS PP ON Pep.PeptideID=PP.PeptideID
+                JOIN PeptideScores AS PepS ON Pep.PeptideID=PepS.PeptideID
+                JOIN ProteinAnnotations AS PA ON PP.ProteinID=PA.ProteinID
+                JOIN SpectrumHeaders AS SH ON Pep.SpectrumID=SH.SpectrumID
+                """
+        wheres = []
+        if sequence:
+            wheres.append(' Pep.Sequence LIKE "%' + str(sequence) + '%" ')
+        if protein_id:
+            wheres.append(' PP.ProteinID=' + str(protein_id) + ' ')
+        if protein_description:
+            wheres.append(' PA.Description LIKE "%' + str(protein_description) + '%"')
+        if peptide_min_score:
+            wheres.append(' PepS.ScoreValue >= ' + str(peptide_min_score) + ' ')
+        if scan_number:
+            wheres.append(' SH.ScanNumbers =' + str(scan_number) + ' ')
+        if confidence_level:
+            wheres.append(' Pep.ConfidenceLevel >= ' + str(confidence_level) + ' ')
+        if search_engine_rank:
+            wheres.append(' Pep.SearchEngineRank <= ' + str(search_engine_rank) + ' ')
+              
+        if len(wheres) > 0:
+            query += 'WHERE' + ' AND'.join(wheres)
+            
+        if best:
+            query += """GROUP BY Pep.Sequence"""
+          
+        peptides = []       
+        try:
+            for item in self.cur.execute(query):
+                peptides.append({
+                               'sequence': item[0],
+                               'score': item[1],
+                               'protein_id': item[2],
+                               'description': item[3],
+                               'scan_number': item[4],
+                               'mass': item[5],
+                               'charge': item[6],
+                               'scan_time': item[7]
+                              })
+        except sqlite3.OperationalError:
+            pass
+
+        output = pd.DataFrame(peptides)
+        return output
+
+def main(args):
+
+    msf = ProteomeDiscovererMSF(args.files)
+    df = msf.proteins()
+
+    # TODO serialize dataframe?
+    
+    df.to_csv(args.output)
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
@mwvaughn adding an MSF parser for Thermo-Fisher mass-spec files from Gingko. 

This attempts to align to conventions being established in: https://github.com/SD2E/reactors-etl/tree/master/reactors/fcs-tasbe-tacc

The following works locally
```
./build.sh 
./example/agave_runner.sh
```
I used exp2801-04-ds731218.msf
at: s3://sd2e-q0-ta3-example-data/uploads/lcms/Ginkgo proteomics examples/

Where possible I have updated TACC relevant JSON, YAML, etc. although I have not been able to test these on the platform yet. I look forward to doing so!

In particular, the input/output linking is something I'm not 100% on yet - I can see how I specify inputs in the app.yml. Is the intent for this to be translated to an on-demand agave-runner that includes the necessary args? 

Thanks!
