### PR TITLE
update lcms parser to more closely follow TACC/Agave conventions

### DIFF
--- a/reactors/lcms/Dockerfile
+++ b/reactors/lcms/Dockerfile
@@ -1,10 +1,32 @@
-FROM python:2.7.13
+# Pin to a specific major version, not latest
+# xenial = 16.0.4 LTS
+# trusty = 14.0.4 LTS
 
-ADD src/lcms.py /
+FROM ubuntu:xenial
 
-RUN pip install argparse
+RUN apt-get update
+RUN apt-get install python -y
+RUN apt-get install python-pip -y
+RUN pip install --upgrade pip
 RUN pip install pandas
 RUN pip install pyteomics
 RUN pip install lxml
 
-CMD python ./lcms.py --in $IN --out $OUT
+# Customizing 101
+# 
+# 1. Try to avoid working in / (unless that's your intent)
+# 2. Do ADD and COPY operations as late as possible as 
+#    they invalidate the Docker cache on downstream layers
+# 3. Import archive files from GitHub using tagged releases
+# 4. Clean up your build directories when done
+# 5. Put scripts and other assets in relatively standard places
+# 6. Don't actually have the default ENTRYPOINT or 
+#    CMD do work. Enlist it for debugging instead.
+
+WORKDIR /root
+
+RUN mkdir -p /opt/scripts
+
+ADD src /opt/scripts
+
+CMD /usr/bin/env

--- a/reactors/lcms/example/_util/container_exec.sh
+++ b/reactors/lcms/example/_util/container_exec.sh
@@ -1,0 +1,58 @@
+
+function container_exec() {
+    
+    # [TODO] Check for existence of docker or singularity executable
+    # [TODO] Enable honoring a DEBUG global
+    # [TODO] Figure out how to accept more optional arguments (env-file, etc)
+    # [TODO] Better error handling and reporting
+
+    local CONTAINER_IMAGE=$1
+    shift
+    local COMMAND=$1
+    shift
+    local PARAMS=$@
+
+    echo $CONTAINER_IMAGE
+    echo $COMMAND
+    echo $PARAMS
+
+    if [ -z "$SINGULARITY_PULLFOLDER" ];
+    then
+        if [ ! -z "$STOCKYARD" ];
+        then
+            SINGULARITY_PULLFOLDER="${STOCKYARD}/.singularity/pull"
+        else
+            SINGULARITY_PULLFOLDER="$HOME/.singularity"
+        fi
+    fi
+
+    if [ -z "$SINGULARITY_CACHEDIR" ];
+    then
+        if [ ! -z "$STOCKYARD" ];
+        then
+            SINGULARITY_CACHEDIR="${STOCKYARD}/.singularity/cache"
+        else
+            SINGULARITY_CACHEDIR="$HOME/.singularity"
+        fi
+    fi
+
+    if [[ "$_CONTAINER_ENGINE" == "docker" ]];
+    then
+        local OPTS="-v $PWD:/home:rw -w /home --rm=true"
+        if [ ! -z "$ENVFILE" ]
+        then
+            OPTS="$OPTS --env-file ${ENVFILE}"
+        fi
+        set -x
+        docker run $OPTS ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}
+        set +x
+    elif [[ "$_CONTAINER_ENGINE" == "singularity" ]];
+    then
+        # [TODO] Detect if a .img has been passed it (rare)
+        # [TODO]
+        singularity exec docker://${DOCKER_CONTAINER} "${COMMAND}"
+    else
+        echo "_CONTAINER_ENGINE needs to be 'docker' or 'singularity' [$_CONTAINER_ENGINE]"
+    fi
+
+}

--- a/reactors/lcms/example/agave-runner.sh
+++ b/reactors/lcms/example/agave-runner.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script simulates the job execution environment for TACC's Agave
+# platform. An emphemeral working directory has been created, files have
+# been copied into place at the root level of that directory, and a
+# task runner has been written out to the directory (*.ipcexe). In a 
+# batch (HPC) system, the script will be actually be a scheduler job 
+# script while on an interactive (CLI) system, the script itself is 
+# executed in this directory on the host
+
+_CONTAINER_ENGINE=${_CONTAINER_ENGINE:-docker} 
+. _util/container_exec.sh
+
+CONTAINER_IMAGE="lcms:latest"
+COMMAND='python'
+PARAMS='/opt/scripts/lcms.py --file ec_K12.fasta --output ec_K12.csv'
+
+container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}

--- a/reactors/lcms/example/agave-runner.sh.ipcexe
+++ b/reactors/lcms/example/agave-runner.sh.ipcexe
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This script simulates the job execution environment for TACC's Agave
+# platform. An emphemeral working directory has been created, files have
+# been copied into place at the root level of that directory, and a
+# task runner has been written out to the directory (*.ipcexe). In a 
+# batch (HPC) system, the script will be actually be a scheduler job 
+# script while on an interactive (CLI) system, the script itself is 
+# executed in this directory on the host
+
+_CONTAINER_ENGINE=${_CONTAINER_ENGINE:-singularity}
+. _util/container_exec.sh
+
+CONTAINER_IMAGE="sd2e/lcms:latest" # ${docker_org}${docker_image}${image_tag}
+# ${file1} ${label1} ${type} ${output}
+COMMAND='python'
+PARAMS='/opt/scripts/lcms.py --file ec_K12.fasta --output ec_K12.csv'
+
+container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}

--- a/reactors/lcms/example/app.json
+++ b/reactors/lcms/example/app.json
@@ -1,0 +1,62 @@
+{
+    "checkpointable": false,
+    "name": "lcms",
+    "executionSystem": "hpc-tacc-maverick",
+    "executionType": "HPC",
+    "deploymentPath": "apps/lcms",
+    "deploymentSystem": "data-sd2e-app-assets",
+    "helpURI": "https://sd2e.org/develop/",
+    "label": "LCMS Parser",
+    "longDescription": "",
+    "modules": ["load tacc-singularity/2.3.1"],
+    "ontology": ["http://sswapmeet.sswap.info/agave/apps/Application"],
+    "parallelism": "SERIAL",
+    "shortDescription": "",
+    "tags": ["lcms"],
+    "templatePath": "agave-runner.sh",
+    "testPath": "agave-tester.sh",
+    "version": "0.1.0",
+    "inputs": [{
+      "id": "files",
+      "details": {
+        "label": "FASTA or mzML file",
+        "showAttribute": false
+      },
+      "semantics": {
+        "minCardinality": 1,
+        "ontology": [
+          "http://sswapmeet.sswap.info/util/Sequence"
+        ],
+        "fileTypes": [
+          "text-0"
+        ]
+      },
+      "value": {
+        "default": "agave://data-tacc-work-vaughn/examples/wc/test.txt",
+        "required": true,
+        "visible": true
+      }
+    }],
+    "parameters": [
+        {
+            "id": "output",
+            "value": {
+                "default": "output",
+                "type": "string",
+                "validator": "",
+                "visible": true,
+                "required": false
+            },
+            "details": {
+                "label": "Output file name"
+            },
+            "semantics": {
+                "ontology": [
+                    "xs:string"
+                ]
+            }
+        }
+    ],
+    "outputs": [],
+    "defaultMaxRunTime": "00:15:00"
+}

--- a/reactors/lcms/example/app.jsonx
+++ b/reactors/lcms/example/app.jsonx
@@ -1,0 +1,23 @@
+{
+	"checkpointable": false,
+	"name": "${APP_NAME}",
+	"executionSystem": "${APP_EXECUTIONSYSTEM}",
+	"executionType": "${APP_TYPE}",
+	"deploymentPath": "apps/docker-run",
+	"deploymentSystem": "data-sd2e-app-assets",
+	"helpURI": "https://sd2e.org/develop/",
+	"label": "docker run (${APP_TYPE})",
+	"longDescription": "Automatically generated: ${GENDATE}",
+	"modules": ['load singularity'],
+	"ontology": ["http://sswapmeet.sswap.info/agave/apps/Application"],
+	"parallelism": "SERIAL",
+	"shortDescription": "Pull and execute the default ENTRYPOINT of a Docker container image using Singularity",
+	"tags": ["test", "hello"],
+	"templatePath": "code/runner.sh",
+	"testPath": "code/tester.sh",
+	"version": "${APP_VERSION}",
+	"inputs": [],
+	"parameters": [],
+	"outputs": [],
+	"defaultMaxRunTime": "00:10:00"
+}

--- a/reactors/lcms/example/app.yml
+++ b/reactors/lcms/example/app.yml
@@ -1,0 +1,18 @@
+---
+inputs:
+  files:
+    default_value: "file:///ec_K12.fasta"
+    test_value: "file:///ec_K12.fasta"
+    label: "fasta or mzML file"
+  config:
+    default_value: "file:///lcms.json"
+    test_value: "file:///lcms.json"
+    label: "Configuration file (JSON)"
+parameters:
+outputs:
+runtime:
+  template: "agave-runner.sh"
+  container:
+    docker_org: "sd2e/"
+    docker_image: "lcms"
+    image_tag: ":latest"

--- a/reactors/lcms/run.sh
+++ b/reactors/lcms/run.sh
@@ -1,1 +1,0 @@
-docker run -v $PWD:/data -e "IN=/data/ec_K12.fasta" -e "OUT=/data/out.txt" lcms

--- a/reactors/lcms/src/lcms.py
+++ b/reactors/lcms/src/lcms.py
@@ -5,7 +5,7 @@ This is a tool to auto-generate data set summaries.
 Example:
     Recommended way to run this tool is:
 
-        $ python lcms.py --in <input_filename> --out <output_filename>
+        $ python lcms.py --files <input_filename> --output <output_filename>
 
 """
 import pandas as pd
@@ -13,14 +13,18 @@ import numpy as np
 import argparse
 from pyteomics import mgf, mzml, fasta, auxiliary 
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--files', help='Input fasta or mzML file(s) for parsing', required=True)
+parser.add_argument('--output', help='Name of output CSV file', default='output.csv')
+
 def ingest_mgf(input_filename):
-    """Ingest an mgf file given it's name and return a dataframe of the file
+    """Ingest an mgf file given its name and return a dataframe of the file
     """
     with mgf.read('tests/test.mgf') as reader:
         auxiliary.print_tree(next(reader))
 
 def ingest_fasta(input_filename):
-    """Ingest an fasta file given it's name and return a dataframe of the file
+    """Ingest an fasta file given its name and return a dataframe of the file
     """
     with fasta.read(input_filename) as reader:
         for entry in reader:
@@ -35,24 +39,16 @@ def ingest_mzML(input_filename):
     with mzml.read('tests/test.mzML') as reader:
         auxiliary.print_tree(next(reader))
         
-def main():
+def main(args):
     
-    #Parse the arguments to read in the file name and export another file
-    parser = argparse.ArgumentParser(description='LC/MS ETL')
-    parser.add_argument("--in", help="Input Filename",  required=True)
-    parser.add_argument("--out", help="Output Filename", required=True)
-    args = vars(parser.parse_args())
-    
-    #variables will be
-    print "args",args["in"],"---",args["out"]
-    
-    if "mgf" in args["in"]:
-        ingest_mgf(args["in"])
-    elif "fasta" in args["in"]:
-        df = ingest_fasta(args["in"])
-        print df.shape
+    if "mgf" in args.files:
+        ingest_mgf(args.files)
+    elif "fasta" in args.files:
+        df = ingest_fasta(args.files)
+        df.to_csv(args.output)
     else:
-        ingest_mzML(args["in"])
+        ingest_mzML(args.files)
 
-if __name__ == "__main__":
-    main()
+if __name__ == '__main__':
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
In the vein of: https://github.com/SD2E/reactors-etl/pull/4

This updates the lcms parser to better align to conventions being established in: https://github.com/SD2E/reactors-etl/tree/master/reactors/fcs-tasbe-tacc

The following works locally:
```
./build.sh 
./example/agave_runner.sh
```
I used ec_K12.fasta at: s3://sd2e-q0-ta3-example-data/uploads/lcms/ec_K12.fasta

Where possible I have updated TACC relevant JSON, YAML, etc. although I have not been able to test these on the platform yet.