### PR TITLE
Initial support for mzml parsing, update tester.sh

### DIFF
--- a/reactors/lcms/lcms-0.1.0/tester.sh
+++ b/reactors/lcms/lcms-0.1.0/tester.sh
@@ -13,6 +13,8 @@ PARAMS='/opt/scripts/lcms.py --files localtest/ec_K12.fasta --output ec_K12.csv'
 
 DEBUG=1 container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}
 
+#PARAMS='/opt/scripts/lcms.py --files localtest/exp1720-04-ds259269.mzML --output exp1720-04-ds259269.csv'
+#DEBUG=1 container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}
 
 ######################
 #  FUNCTIONAL TESTS  #
@@ -24,23 +26,40 @@ DEBUG=1 container_exec ${CONTAINER_IMAGE} ${COMMAND} ${PARAMS}
 function run_tests() {
 
     validate_csv ec_K12.csv
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+    #validate_csv exp1720-04-ds259269.csv
+    #if [ $? -ne 0 ]; then
+    #    return 1
+    #fi
     return 0
 }
 
 function validate_csv() {
-
-    return 0
-
+    if [ -f "$1" ]; then
+        return 0
+    else
+        echo "$1 not found"
+        return 1
+    fi
 }
 
 function cleanup() {
 
+    echo "Cleaning up..."
     rm -f ec_K12.csv
+    #rm -f exp1720-04-ds259269.csv
     rm -f .container_exec.*
-
 }
 
-run_tests && \
-    echo "Success" && \
-    cleanup
+trap cleanup EXIT
 
+run_tests
+if [ $? -eq 0 ]; then
+    echo "Success!"
+    exit 0
+else
+    echo "Test failed!"!
+    exit 1
+fi

--- a/reactors/lcms/push.sh
+++ b/reactors/lcms/push.sh
@@ -2,4 +2,4 @@
 
 CONTAINER_IMAGE="sd2e/lcms:latest"
 
-docker build -t ${CONTAINER_IMAGE} .
+docker push ${CONTAINER_IMAGE}

--- a/reactors/lcms/src/lcms.py
+++ b/reactors/lcms/src/lcms.py
@@ -36,8 +36,73 @@ def ingest_fasta(input_filename):
 def ingest_mzML(input_filename):
     """Ingest an mzML or mzXML file given it's name and return a dataframe of the file
     """
-    with mzml.read('tests/test.mzML') as reader:
-        auxiliary.print_tree(next(reader))
+    '''
+    {'count': 2,
+    'index': 2,
+    'highest observed m/z': 2020.216835219264,
+    'm/z array': array([  346.51808351
+    'ms level': 1,
+    'total ion current': 5284812.0,
+    'profile spectrum': '',
+    'lowest observed m/z': 346.518083514683,
+    'defaultArrayLength': 6305,
+    'intensity array':,
+    'positive scan': '',
+    'MS1 spectrum': '',
+    'spectrum title': 'exp1720-04-ds259269.3.3. File:"exp1720-04-ds259269.raw", NativeID:"controllerType=0 controllerNumber=1 scan=3"',
+    'base peak intensity': 836452.44,
+    'scanList': {'count': 1, 'no combination': '', 'scan': [{'filter string': 'FTMS + p NSI Full ms [350.00-2000.00]',
+    'scan start time': 5.0165227,
+    'ion injection time': 100.000001490116,
+    'scanWindowList': {'count': 1, 'scanWindow': [{'scan window lower limit': 350.0, 'scan window upper limit': 2000.0}]}, 'preset scan configuration': 1.0}]},
+    'id': 'controllerType=0 controllerNumber=1 scan=3',
+    'base peak m/z': 371.1017749}
+        '''
+    with mzml.read(input_filename) as reader:
+        mzml_list = [
+            #item["count"],
+            #item["index"],
+            [float(item["highest observed m/z"]),
+             #item["m/z array"],
+             int(item["ms level"]),
+             float(item["total ion current"]),
+             #item["profile spectrum"],
+             float(item["lowest observed m/z"]),
+             #item["intensity array"],
+             #item["positive scan"],
+             #item["MS1 spectrum"],
+             #exp1720-04-ds259269.3.3. File:"exp1720-04-ds259269.raw", NativeID:"controllerType=0 controllerNumber=1 scan=3"
+             str(item["spectrum title"].split("File:\"")[1].split("\",")[0]),
+             int(item["spectrum title"].split("controllerType=")[1].split(" ")[0]),
+             int(item["spectrum title"].split("controllerNumber=")[1].split(" ")[0]),
+             int(item["spectrum title"].split("scan=")[1].split("\"")[0]),
+             float(item["base peak intensity"]),
+             #item["scanList"],
+             #item["id"],
+             float(item["base peak m/z"])
+             ] for item in reader]
+    df = pd.DataFrame(mzml_list,columns=[
+        #"count",
+        #"index",
+        "highest observed m/z",
+        #"m/z array",
+        "ms level",
+        "total ion current",
+        #"profile spectrum",
+        "lowest observed m/z",
+        #"intensity array",
+        #"positive scan",
+        #"MS1 spectrum",
+        "filename",
+        "controllerType",
+        "controllerNumber",
+        "scan",
+        "base peak intensity",
+        #"scanList",
+        #"id",
+        "base peak m/z"])
+
+    return df
         
 def main(args):
     
@@ -45,9 +110,12 @@ def main(args):
         ingest_mgf(args.files)
     elif "fasta" in args.files:
         df = ingest_fasta(args.files)
-        df.to_csv(args.output)
+    elif "mzML" in args.files:
+        df = ingest_mzML(args.files)
     else:
-        ingest_mzML(args.files)
+        raise ValueError('Could not parse:' + args.files)
+
+    df.to_csv(args.output)
 
 if __name__ == '__main__':
     args = parser.parse_args()


### PR DESCRIPTION
This adds initial support for mzml parsing, producing the following columns as an example:

| ﻿highest observed m/z | ms level | total ion current | lowest observed m/z | filename                | controllerType | controllerNumber | scan | base peak intensity | base peak m/z |
|----------------------|----------|-------------------|---------------------|-------------------------|----------------|------------------|------|---------------------|---------------|
| 2020.219487          | 1        | 5169367.5         | 346.5185385         | exp1720-04-ds259269.raw | 0              | 1                | 1    | 841227.38           | 371.1022651   |

I did some work to update tester.sh, but this somewhat for naught - the smallest .mzML file we have is 300+ MB and github complained about this. I commented out the tests for that for now (it does work) and left the other improvements in, such as implementing validate_csv and ensuring we always cleanup.

```
remote: Resolving deltas: 100% (5/5), completed with 5 local objects.
remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
remote: error: Trace: 3d3bef7db6736aad460018767c2ca5a7
remote: error: See http://git.io/iEPt8g for more information.
remote: error: File reactors/lcms/lcms-0.1.0/localtest/exp1720-04-ds259269.mzML is 295.77 MB; this exceeds GitHub's file size limit of 100.00 M
```

@mwvaughn @jegentile I've already noticed that pulling the repo is taking a while with some of these large files as they build up. Very useful for local testing, but difficult when I'm on this weak airport Wifi. We'll need to think about a better longer term solution: https://github.com/SD2E/reactors-etl/issues/2

Also build.sh and push.sh were separated out.