### PR TITLE
Limit test data sync to just the files needed for testing, fix --recursive issue

### DIFF
--- a/reactors/lcms/import-test-data.sh
+++ b/reactors/lcms/import-test-data.sh
@@ -21,15 +21,12 @@ function _import_agave_uri() {
     local RECURSE=
     case "$APATH" in
         */)
-            RECURSE="--recursive "
+            files-get "--recursive" -S "${ASYS}" -N "${DEST}" "${APATH}"
             ;;
         *)
-            RECURSE=""
+            files-get -S "${ASYS}" -N "${DEST}" "${APATH}"
             ;;
     esac
-
-    files-get "${RECURSE}" -S "${ASYS}" -N "${DEST}" "${APATH}"
-
 }
 
 function _import_public_uri() {

--- a/reactors/lcms/test-data.tsv
+++ b/reactors/lcms/test-data.tsv
@@ -1,2 +1,2 @@
-agave://data-sd2e-community/sample/lcms/Ginko_proteomics_examples/   Ginko_proteomics_examples
+agave://data-sd2e-community/sample/lcms/Ginko_proteomics_examples/exp1720-04-ds259269.mzML exp1720-04-ds259269.mzML
 agave://data-sd2e-community/sample/lcms/ec_K12.fasta K12.fasta


### PR DESCRIPTION
Testing locally, this would sync multiple gigs of data over HTTP - limit the test to just the single file needed.

Also fix an issue with shell invocation on OSX in import-test-data.sh related to the use of --recursive:

```
+ files-get '' -S data-sd2e-community -N test-data-cache/K12.fasta sample/lcms/ec_K12.fasta
Please specify a valid file path to download. Directory downloads are not yet supported.
stty: stdin isn't a terminal
```

Now, the following works locally:
```
./import-test-data.sh
./stage-test-data.sh lcms-0.1.0
cd lcms-0.1.0
./tester.sh
```